### PR TITLE
fix "light" typo

### DIFF
--- a/docs/devilbox-purpose.rst
+++ b/docs/devilbox-purpose.rst
@@ -11,7 +11,7 @@ Its main intention is to support an unlimited number of projects for any framewo
 and be portable accross all major operating systems, as well as providing any available php version
 with whatever module you require.
 
-To be portable, customizable and as leight weight as possible, the choice fell on a Dockerized
+To be portable, customizable and as light weight as possible, the choice fell on a Dockerized
 setup.
 
 


### PR DESCRIPTION
### **User description**
# fix typo

change `leight` to `light`


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed typo in documentation: `leight` to `light`


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devilbox-purpose.rst</strong><dd><code>Fix spelling typo in documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/devilbox-purpose.rst

<ul><li>Corrected spelling error from <code>leight</code> to <code>light</code> in project description</ul>


</details>


  </td>
  <td><a href="https://github.com/devilbox-community/devilbox/pull/9/files#diff-12f833e15f5cecc57b65d2230cc9e7640ac9565aa870853160ab29a13803386c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

