### PR TITLE
fix "project" typo

### DIFF
--- a/docs/configuration-files/env-file.rst
+++ b/docs/configuration-files/env-file.rst
@@ -1378,7 +1378,7 @@ Let's have a look how the directory is actually built up:
    total 4
    -rw-r--r-- 1 cytopia cytopia 87 Mar 12 23:05 index.php
 
-By calling your proect url, the ``index.php`` file will be served.
+By calling your project url, the ``index.php`` file will be served.
 
 
 **Directory structure: nested symlink**


### PR DESCRIPTION
### **User description**
# fix typo

change `proect` to `project`


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed typo in documentation: "proect" → "project"


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>env-file.rst</strong><dd><code>Fix typo in documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/configuration-files/env-file.rst

- Fixed typo "proect" to "project" in documentation text


</details>


  </td>
  <td><a href="https://github.com/devilbox-community/devilbox/pull/10/files#diff-351056bb0e416819f1a543339e87fbdfbdf558b284af289a0d3889a16da40d86">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

